### PR TITLE
[Feat] 6차 세미나 실습 과제

### DIFF
--- a/week2_PA/build.gradle
+++ b/week2_PA/build.gradle
@@ -30,6 +30,16 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	testImplementation 'io.rest-assured:rest-assured'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	//JWT
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+	//Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	//Multipart file
+	implementation("software.amazon.awssdk:bom:2.21.0")
+	implementation("software.amazon.awssdk:s3:2.21.0")
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis:2.3.1.RELEASE'
 }
 
 tasks.named('test') {

--- a/week2_PA/src/main/java/org/geniuus/practice/Common/BusinessException.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/Common/BusinessException.java
@@ -1,7 +1,9 @@
 package org.geniuus.practice.Common;
 
+import lombok.Getter;
 import org.geniuus.practice.Common.dto.ErrorMessage;
 
+@Getter
 public class BusinessException extends RuntimeException {
     public ErrorMessage errorMessage;
 

--- a/week2_PA/src/main/java/org/geniuus/practice/Common/GlobalExceptionHandler.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/Common/GlobalExceptionHandler.java
@@ -1,8 +1,6 @@
 package org.geniuus.practice.Common;
 
-import jakarta.persistence.EntityNotFoundException;
 import org.geniuus.practice.Common.dto.ErrorResponse;
-import org.springframework.data.crossstore.ChangeSetPersister;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -27,5 +25,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ForbiddenException.class)
     protected ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException e) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ErrorResponse.of(e.errorMessage));
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    protected ResponseEntity<ErrorResponse> handlerUnauthorizedException(UnauthorizedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ErrorResponse.of(e.getErrorMessage().getStatus(), e.getErrorMessage().getMessage()));
     }
 }

--- a/week2_PA/src/main/java/org/geniuus/practice/Common/UnauthorizedException.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/Common/UnauthorizedException.java
@@ -1,0 +1,9 @@
+package org.geniuus.practice.Common;
+
+import org.geniuus.practice.Common.dto.ErrorMessage;
+
+public class UnauthorizedException extends BusinessException {
+    public UnauthorizedException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/week2_PA/src/main/java/org/geniuus/practice/Common/dto/ErrorMessage.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/Common/dto/ErrorMessage.java
@@ -11,6 +11,8 @@ public enum ErrorMessage {
     BLOG_FORBIDDEN_BY_MEMBER_EXCEPTION(HttpStatus.FORBIDDEN.value(), "ID에 해당하는 사용자가 해당 블로그에 쓰기 권한이 없습니다."),
     POST_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "검색할 포스트가 존재하지 않습니다"),
     BLOG_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 블로그가 존재하지 않습니다"),
+    JWT_UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED.value(), "사용자의 로그인 검증을 실패했습니다."),
+    PASSWORD_NOT_MATCHED_EXCEPTION(HttpStatus.UNAUTHORIZED.value(), "해당 유저의 비밀번호가 일치하지 않습니다."),
     ;
 
     private final int status;

--- a/week2_PA/src/main/java/org/geniuus/practice/Common/dto/SuccessMessage.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/Common/dto/SuccessMessage.java
@@ -11,6 +11,8 @@ public enum SuccessMessage {
     BLOG_CREATE_SUCCESS(HttpStatus.CREATED.value(), "블로그 생성이 완료되었습니다."),
     POST_CREATE_SUCCESS(HttpStatus.CREATED.value(), "포스팅이 완료되었습니다."),
     POST_FIND_SUCCESS(HttpStatus.OK.value(), "포스팅 검색이 완료되었습니다."),
+    TOKEN_REFRESH_SUCCESS(HttpStatus.OK.value(), "토큰 재발급이 완료되었습니다."),
+    MEMBER_LOGIN_SUCCESS(HttpStatus.OK.value(), "로그인이 완료되었습니다."),
     ;
 
     private final int status;

--- a/week2_PA/src/main/java/org/geniuus/practice/Common/jwt/JwtTokenProvider.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/Common/jwt/JwtTokenProvider.java
@@ -1,0 +1,83 @@
+package org.geniuus.practice.Common.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private static final String USER_ID = "memberId";
+
+    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 14;
+    private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 60 * 60 * 24 * 1000L * 14;
+
+    @Value("${jwt.secret}")
+    private String JWT_SECRET;
+
+
+    public String issueAccessToken(final Authentication authentication) {
+        return generateToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME);
+    }
+
+    public String issueRefreshToken(final Authentication authentication) {
+        return generateToken(authentication, REFRESH_TOKEN_EXPIRATION_TIME);
+    }
+
+
+    public String generateToken(Authentication authentication, Long tokenExpirationTime) {
+        final Date now = new Date();
+        final Claims claims = Jwts.claims()
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + tokenExpirationTime));      // 만료 시간
+
+        claims.put(USER_ID, authentication.getPrincipal());
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE) // Header
+                .setClaims(claims) // Claim
+                .signWith(getSigningKey()) // Signature
+                .compact();
+    }
+
+    private SecretKey getSigningKey() {
+        String encodedKey = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes()); //SecretKey 통해 서명 생성
+        return Keys.hmacShaKeyFor(encodedKey.getBytes());   //일반적으로 HMAC (Hash-based Message Authentication Code) 알고리즘 사용
+    }
+
+    public JwtValidationType validateToken(String token) {
+        try {
+            final Claims claims = getBody(token);
+            return JwtValidationType.VALID_JWT;
+        } catch (MalformedJwtException ex) {
+            return JwtValidationType.INVALID_JWT_TOKEN;
+        } catch (ExpiredJwtException ex) {
+            return JwtValidationType.EXPIRED_JWT_TOKEN;
+        } catch (UnsupportedJwtException ex) {
+            return JwtValidationType.UNSUPPORTED_JWT_TOKEN;
+        } catch (IllegalArgumentException ex) {
+            return JwtValidationType.EMPTY_JWT;
+        }
+    }
+
+    private Claims getBody(final String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public Long getUserFromJwt(String token) {
+        Claims claims = getBody(token);
+        return Long.valueOf(claims.get(USER_ID).toString());
+    }
+}

--- a/week2_PA/src/main/java/org/geniuus/practice/Common/jwt/JwtValidationType.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/Common/jwt/JwtValidationType.java
@@ -1,0 +1,10 @@
+package org.geniuus.practice.Common.jwt;
+
+public enum JwtValidationType {
+    VALID_JWT,              // 유효한 JWT
+    INVALID_JWT_SIGNATURE,      // 유효하지 않은 서명
+    INVALID_JWT_TOKEN,          // 유효하지 않은 토큰
+    EXPIRED_JWT_TOKEN,          // 만료된 토큰
+    UNSUPPORTED_JWT_TOKEN,      // 지원하지 않는 형식의 토큰
+    EMPTY_JWT                   // 빈 JWT
+}

--- a/week2_PA/src/main/java/org/geniuus/practice/Controller/BlogController.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/Controller/BlogController.java
@@ -7,9 +7,12 @@ import org.geniuus.practice.Common.dto.SuccessMessage;
 import org.geniuus.practice.Common.dto.SuccessStatusResponse;
 import org.geniuus.practice.Service.BlogService;
 import org.geniuus.practice.Service.dto.BlogCreateRequest;
+import org.geniuus.practice.auth.PrincipalHandler;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -17,15 +20,24 @@ import org.springframework.web.bind.annotation.*;
 public class BlogController {
 
     private final BlogService blogService;
+    private final PrincipalHandler principalHandler;
+
+//    @PostMapping("/blog")
+//    public ResponseEntity<SuccessStatusResponse> createBlog(
+//            @RequestHeader Long memberId,
+//            @RequestBody BlogCreateRequest blogCreateRequest) {
+//        return ResponseEntity.status(HttpStatus.CREATED).header(
+//                        "Location",
+//                        blogService.create(memberId, blogCreateRequest))
+//                .body(SuccessStatusResponse.of(SuccessMessage.BLOG_CREATE_SUCCESS));
+//    }
 
     @PostMapping("/blog")
-    public ResponseEntity<SuccessStatusResponse> createBlog(
-            @RequestHeader Long memberId,
-            @RequestBody BlogCreateRequest blogCreateRequest) {
-        return ResponseEntity.status(HttpStatus.CREATED).header(
-                        "Location",
-                        blogService.create(memberId, blogCreateRequest))
-                .body(SuccessStatusResponse.of(SuccessMessage.BLOG_CREATE_SUCCESS));
+    public ResponseEntity createBlog(
+            @ModelAttribute BlogCreateRequest blogCreateRequest
+    ) {
+        return ResponseEntity.created(URI.create(blogService.create(
+                principalHandler.getUserIdFromPrincipal(), blogCreateRequest))).build();
     }
 
     @PatchMapping("/blog/{blogId}/title")
@@ -36,8 +48,6 @@ public class BlogController {
         blogService.updateTitle(blogId, blogTitleUpdateRequest);
         return ResponseEntity.noContent().build();
     }
-
-
 
 }
 

--- a/week2_PA/src/main/java/org/geniuus/practice/Controller/MemberController.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/Controller/MemberController.java
@@ -1,49 +1,57 @@
 package org.geniuus.practice.Controller;
 
 import lombok.RequiredArgsConstructor;
+import org.geniuus.practice.Common.dto.SuccessMessage;
+import org.geniuus.practice.Common.dto.SuccessStatusResponse;
 import org.geniuus.practice.Service.MemberService;
-import org.geniuus.practice.Service.dto.MemberCreateDto;
-import org.geniuus.practice.Service.dto.MemberFindDto;
-import org.geniuus.practice.Service.dto.MembersDto;
+import org.geniuus.practice.Service.dto.*;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.net.URI;
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/member")
+@RequestMapping("/api/v1")
 public class MemberController {
 
     private final MemberService memberService;
 
-    @PostMapping
-    public ResponseEntity createMember(
-            @RequestBody MemberCreateDto memberCreateDto
-    ) {
-        return ResponseEntity.created(URI.create(memberService.createMember(memberCreateDto)))
-                .build();
-    }
-
-    @GetMapping
+    @GetMapping("/member")
     public ResponseEntity<List<MembersDto>> findMembers() {
         return ResponseEntity.ok(memberService.findMembers());
     }
 
-    @GetMapping("/{memberId}")
-    public ResponseEntity<MemberFindDto> findMemberById(
-            @PathVariable Long memberId
-    ) {
+    @GetMapping("/member/{memberId}")
+    public ResponseEntity<MemberFindDto> findMemberById (@PathVariable Long memberId) {
         return ResponseEntity.ok(memberService.findMemberById(memberId));
     }
 
-    @DeleteMapping("/{memberId}")
-    public ResponseEntity deleteMember(
-            @PathVariable Long memberId
-    ) {
+    @DeleteMapping("/member/{memberId}")
+    public ResponseEntity deleteMember (@PathVariable Long memberId) {
         memberService.deleteMemberById(memberId);
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/member")
+    public ResponseEntity<MemberResponseWithTokens> createMember(
+            @RequestBody MemberCreateRequest memberCreateRequest
+    ) {
+        MemberResponseWithTokens memberResponseWithTokens = memberService.createMember(memberCreateRequest);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .header("Location", memberResponseWithTokens.memberId().toString())
+                .body(memberResponseWithTokens);
+    }
+
+    @PostMapping("/member/login")
+    public ResponseEntity<SuccessStatusResponse<MemberResponseWithTokens>> login(
+            @RequestBody MemberLoginRequest memberLoginRequest
+    ) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessStatusResponse.of(SuccessMessage.MEMBER_LOGIN_SUCCESS, memberService.login(memberLoginRequest)));
+    }
+
+
 
 }

--- a/week2_PA/src/main/java/org/geniuus/practice/Controller/PostController.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/Controller/PostController.java
@@ -39,4 +39,6 @@ public class PostController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessStatusResponse.of(SuccessMessage.POST_FIND_SUCCESS, postService.findMultiplePosts(memberId)));
     }
+
+
 }

--- a/week2_PA/src/main/java/org/geniuus/practice/Service/BlogService.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/Service/BlogService.java
@@ -8,8 +8,11 @@ import org.geniuus.practice.Repository.BlogRepository;
 import org.geniuus.practice.Service.dto.BlogCreateRequest;
 import org.geniuus.practice.domain.Blog;
 import org.geniuus.practice.domain.Member;
+import org.geniuus.practice.external.S3Service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
 
 @Service
 @RequiredArgsConstructor
@@ -17,13 +20,28 @@ public class BlogService {
 
     private final BlogRepository blogRepository;
     private final MemberService memberService;
+    private final S3Service s3Service;
+    private static final String BLOG_S3_UPLOAD_FOLDER = "blog/";
 
+//    public String create(Long memberId, BlogCreateRequest createRequest) {
+//        // member 찾기
+//        Member member = memberService.findById(memberId);
+//        Blog blog = blogRepository.save(
+//                Blog.create(member, createRequest));
+//        return blog.getId().toString();
+//    }
+
+    @Transactional
     public String create(Long memberId, BlogCreateRequest createRequest) {
-        // member 찾기
+        //member찾기
         Member member = memberService.findById(memberId);
-        Blog blog = blogRepository.save(
-                Blog.create(member, createRequest));
-        return blog.getId().toString();
+        try {
+            Blog blog = blogRepository.save(Blog.create(member, createRequest.title(), createRequest.description(),
+                    s3Service.uploadImage(BLOG_S3_UPLOAD_FOLDER, createRequest.image())));
+            return blog.getId().toString();
+        } catch (RuntimeException | IOException e) {
+            throw new RuntimeException(e.getMessage());
+        }
     }
 
     @Transactional

--- a/week2_PA/src/main/java/org/geniuus/practice/Service/MemberService.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/Service/MemberService.java
@@ -58,7 +58,7 @@ public class MemberService {
                 UserAuthentication.createUserAuthentication(memberLoginRequest.memberId()));
         String refreshToken = jwtTokenProvider.issueRefreshToken(
                 UserAuthentication.createUserAuthentication(memberLoginRequest.memberId()));
-
+        tokenService.saveRefreshToken(member.getId(), refreshToken);
         return MemberResponseWithTokens.of(accessToken, refreshToken, memberLoginRequest.memberId());
     }
 

--- a/week2_PA/src/main/java/org/geniuus/practice/Service/MemberService.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/Service/MemberService.java
@@ -2,13 +2,17 @@ package org.geniuus.practice.Service;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.geniuus.practice.Common.UnauthorizedException;
 import org.geniuus.practice.Common.dto.ErrorMessage;
 import org.geniuus.practice.Common.NotFoundException;
+import org.geniuus.practice.Common.jwt.JwtTokenProvider;
 import org.geniuus.practice.Repository.MemberRepository;
-import org.geniuus.practice.Service.dto.MemberCreateDto;
-import org.geniuus.practice.Service.dto.MemberFindDto;
-import org.geniuus.practice.Service.dto.MembersDto;
+import org.geniuus.practice.Service.dto.*;
+import org.geniuus.practice.auth.UserAuthentication;
+import org.geniuus.practice.auth.redis.service.TokenService;
 import org.geniuus.practice.domain.Member;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,14 +23,43 @@ import java.util.List;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final TokenService tokenService;
+
+    @Autowired
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public String createMember(
-            MemberCreateDto memberCreateDto
-    ) {
-        Member member = Member.create(memberCreateDto.name(), memberCreateDto.part(), memberCreateDto.age());
-        memberRepository.save(member);
-        return member.getId().toString();
+    public MemberResponseWithTokens createMember (MemberCreateRequest memberCreateRequest) {
+        Member member = memberRepository.save(
+                Member.create(
+                        memberCreateRequest.name(),
+                        passwordEncoder.encode(memberCreateRequest.password()),
+                        memberCreateRequest.part(),
+                        memberCreateRequest.age())
+        );
+
+        String accessToken = jwtTokenProvider.issueAccessToken(
+                UserAuthentication.createUserAuthentication(member.getId()));
+        String refreshToken = jwtTokenProvider.issueRefreshToken(
+                UserAuthentication.createUserAuthentication(member.getId()));
+
+        tokenService.saveRefreshToken(member.getId(), refreshToken);
+        return MemberResponseWithTokens.of(accessToken, refreshToken, member.getId());
+    }
+
+    public MemberResponseWithTokens login(MemberLoginRequest memberLoginRequest) {
+        Member member = memberRepository.findById(memberLoginRequest.memberId()).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND_BY_ID_EXCEPTION)
+        );
+        registerMember(memberLoginRequest.password(), member);
+
+        String accessToken = jwtTokenProvider.issueAccessToken(
+                UserAuthentication.createUserAuthentication(memberLoginRequest.memberId()));
+        String refreshToken = jwtTokenProvider.issueRefreshToken(
+                UserAuthentication.createUserAuthentication(memberLoginRequest.memberId()));
+
+        return MemberResponseWithTokens.of(accessToken, refreshToken, memberLoginRequest.memberId());
     }
 
     public MemberFindDto findMemberById(Long memberId) {
@@ -52,4 +85,10 @@ public class MemberService {
                 () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND_BY_ID_EXCEPTION)
         );
     }
+
+    public void registerMember (String requestPassword, Member member) {
+        if (!passwordEncoder.matches(requestPassword, member.getPassword()))
+            throw new UnauthorizedException(ErrorMessage.PASSWORD_NOT_MATCHED_EXCEPTION);
+    }
+
 }

--- a/week2_PA/src/main/java/org/geniuus/practice/Service/dto/BlogCreateRequest.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/Service/dto/BlogCreateRequest.java
@@ -1,7 +1,10 @@
 package org.geniuus.practice.Service.dto;
 
+import org.springframework.web.multipart.MultipartFile;
+
 public record BlogCreateRequest(
         String title,
-        String description
+        String description,
+        MultipartFile image
 ) {
 }

--- a/week2_PA/src/main/java/org/geniuus/practice/Service/dto/MemberCreateRequest.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/Service/dto/MemberCreateRequest.java
@@ -2,8 +2,9 @@ package org.geniuus.practice.Service.dto;
 
 import org.geniuus.practice.domain.Part;
 
-public record MemberCreateDto(
+public record MemberCreateRequest(
         String name,
+        String password,
         Part part,
         int age
 ) {

--- a/week2_PA/src/main/java/org/geniuus/practice/Service/dto/MemberLoginRequest.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/Service/dto/MemberLoginRequest.java
@@ -1,0 +1,7 @@
+package org.geniuus.practice.Service.dto;
+
+public record MemberLoginRequest(
+        Long memberId,
+        String password
+) {
+}

--- a/week2_PA/src/main/java/org/geniuus/practice/Service/dto/MemberResponseWithTokens.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/Service/dto/MemberResponseWithTokens.java
@@ -1,0 +1,18 @@
+package org.geniuus.practice.Service.dto;
+
+public record MemberResponseWithTokens(
+        String accessToken,
+        String refrshToken,
+        Long memberId
+) {
+
+    public static MemberResponseWithTokens of(
+            String accessToken,
+            String refrshToken,
+            Long memberId
+    ) {
+        return new MemberResponseWithTokens(accessToken, refrshToken, memberId);
+    }
+}
+
+

--- a/week2_PA/src/main/java/org/geniuus/practice/auth/PrincipalHandler.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/auth/PrincipalHandler.java
@@ -1,0 +1,26 @@
+package org.geniuus.practice.auth;
+
+import org.geniuus.practice.Common.UnauthorizedException;
+import org.geniuus.practice.Common.dto.ErrorMessage;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PrincipalHandler {
+
+    private static final String ANONYMOUS_USER = "anonymousUser";
+
+    public Long getUserIdFromPrincipal() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        isPrincipalNull(principal);
+        return Long.valueOf(principal.toString());
+    }
+
+    public void isPrincipalNull(
+            final Object principal
+    ) {
+        if (principal.toString().equals(ANONYMOUS_USER)) {
+            throw new UnauthorizedException(ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION);
+        }
+    }
+}

--- a/week2_PA/src/main/java/org/geniuus/practice/auth/SecurityConfig.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/auth/SecurityConfig.java
@@ -1,0 +1,56 @@
+package org.geniuus.practice.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.geniuus.practice.auth.filter.CustomAccessDeniedHandler;
+import org.geniuus.practice.auth.filter.CustomJwtAuthenticationEntryPoint;
+import org.geniuus.practice.auth.filter.JwtAuthenticationFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity //web Security를 사용할 수 있게
+public class SecurityConfig {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
+
+    private static final String[] AUTH_WHITE_LIST = {"/api/v1/member", "/api/v1/reissuance"};
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .requestCache(RequestCacheConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .exceptionHandling(exception ->
+                {
+                    // Exception Handler 등록
+                    exception.authenticationEntryPoint(customJwtAuthenticationEntryPoint);
+                    exception.accessDeniedHandler(customAccessDeniedHandler);
+                });
+
+        http.authorizeHttpRequests(auth -> {
+                    // WHITE_LIST에 등록된 Path는 전부 허용
+                    auth.requestMatchers(AUTH_WHITE_LIST).permitAll();
+                    auth.anyRequest().authenticated();
+                })
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/week2_PA/src/main/java/org/geniuus/practice/auth/UserAuthentication.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/auth/UserAuthentication.java
@@ -1,0 +1,17 @@
+package org.geniuus.practice.auth;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class UserAuthentication extends UsernamePasswordAuthenticationToken {
+
+    public UserAuthentication(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        super(principal, credentials, authorities);
+    }
+
+    public static UserAuthentication createUserAuthentication(Long userId) {
+        return new UserAuthentication(userId, null, null);
+    }
+}

--- a/week2_PA/src/main/java/org/geniuus/practice/auth/filter/CustomAccessDeniedHandler.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/auth/filter/CustomAccessDeniedHandler.java
@@ -1,0 +1,21 @@
+package org.geniuus.practice.auth.filter;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws ServletException {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+    }
+}
+

--- a/week2_PA/src/main/java/org/geniuus/practice/auth/filter/CustomJwtAuthenticationEntryPoint.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/auth/filter/CustomJwtAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package org.geniuus.practice.auth.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.io.IOException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.geniuus.practice.Common.dto.ErrorMessage;
+import org.geniuus.practice.Common.dto.ErrorResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomJwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, java.io.IOException {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) throws java.io.IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter()
+                .write(objectMapper.writeValueAsString(
+                        ErrorResponse.of(ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION.getStatus(),
+                                ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION.getMessage())));
+    }
+}

--- a/week2_PA/src/main/java/org/geniuus/practice/auth/filter/JwtAuthenticationFilter.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,53 @@
+package org.geniuus.practice.auth.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.geniuus.practice.Common.UnauthorizedException;
+import org.geniuus.practice.Common.dto.ErrorMessage;
+import org.geniuus.practice.Common.jwt.JwtTokenProvider;
+import org.geniuus.practice.Common.jwt.JwtValidationType;
+import org.geniuus.practice.auth.UserAuthentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException, IOException {
+        try {
+            final String token = getJwtFromRequest(request);
+            if (jwtTokenProvider.validateToken(token) == JwtValidationType.VALID_JWT) {
+                Long memberId = jwtTokenProvider.getUserFromJwt(token);
+                UserAuthentication authentication = UserAuthentication.createUserAuthentication(memberId);
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception exception) {
+            throw new UnauthorizedException(ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring("Bearer ".length());
+        }
+        return null;
+    }
+}

--- a/week2_PA/src/main/java/org/geniuus/practice/auth/redis/controller/TokenController.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/auth/redis/controller/TokenController.java
@@ -1,0 +1,27 @@
+package org.geniuus.practice.auth.redis.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.geniuus.practice.Common.dto.SuccessMessage;
+import org.geniuus.practice.Common.dto.SuccessStatusResponse;
+import org.geniuus.practice.auth.redis.service.TokenService;
+import org.geniuus.practice.auth.redis.service.dto.TokenRefreshDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class TokenController {
+
+    private final TokenService tokenService;
+
+    @PostMapping("/reissuance")
+    public ResponseEntity<SuccessStatusResponse<TokenRefreshDto>> reissueTokenByRefreshToken(
+            @RequestBody TokenRefreshDto tokenRefreshRequest
+            ) {
+        return ResponseEntity.ok().body(
+                SuccessStatusResponse.of(
+                        SuccessMessage.TOKEN_REFRESH_SUCCESS,
+                        tokenService.reissueAccessTokenByRefreshToken(tokenRefreshRequest)));
+    }
+}

--- a/week2_PA/src/main/java/org/geniuus/practice/auth/redis/domain/Token.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/auth/redis/domain/Token.java
@@ -1,0 +1,23 @@
+package org.geniuus.practice.auth.redis.domain;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@RedisHash(value = "", timeToLive = 60 * 60 * 24 * 1000L * 14)
+@AllArgsConstructor
+@Getter
+public class Token {
+
+    @Id
+    private Long id;
+
+    @Indexed
+    private String refreshToken;
+
+    public static Token of(final Long id, final String refreshToken) {
+        return new Token(id, refreshToken);
+    }
+}

--- a/week2_PA/src/main/java/org/geniuus/practice/auth/redis/repository/RedisTokenRepository.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/auth/redis/repository/RedisTokenRepository.java
@@ -1,0 +1,10 @@
+package org.geniuus.practice.auth.redis.repository;
+
+import org.geniuus.practice.auth.redis.domain.Token;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface RedisTokenRepository extends CrudRepository<Token, Long> {
+    Optional<Token> findByRefreshToken(final String refreshToken);
+}

--- a/week2_PA/src/main/java/org/geniuus/practice/auth/redis/service/TokenService.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/auth/redis/service/TokenService.java
@@ -1,0 +1,40 @@
+package org.geniuus.practice.auth.redis.service;
+
+import lombok.RequiredArgsConstructor;
+import org.geniuus.practice.Common.UnauthorizedException;
+import org.geniuus.practice.Common.dto.ErrorMessage;
+import org.geniuus.practice.Common.jwt.JwtTokenProvider;
+import org.geniuus.practice.auth.UserAuthentication;
+import org.geniuus.practice.auth.redis.domain.Token;
+import org.geniuus.practice.auth.redis.repository.RedisTokenRepository;
+import org.geniuus.practice.auth.redis.service.dto.TokenRefreshDto;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final RedisTokenRepository redisTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public void saveRefreshToken(Long memberId, String refreshToken) {
+        redisTokenRepository.save(
+                Token.of(memberId, refreshToken));
+    }
+
+    public TokenRefreshDto reissueAccessTokenByRefreshToken(TokenRefreshDto tokenRefreshRequest) {
+        Long tokenId = redisTokenRepository.findByRefreshToken(tokenRefreshRequest.token()).orElseThrow(
+                () -> new UnauthorizedException(ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION)
+        ).getId();
+        Long requestId = tokenRefreshRequest.memberId();
+        validateRequestIdWithTokenId(requestId, tokenId);
+        String accessToken = jwtTokenProvider.issueAccessToken(UserAuthentication.createUserAuthentication(requestId));
+        return TokenRefreshDto.of(requestId, accessToken);
+    }
+
+    public void validateRequestIdWithTokenId(Long requestId, Long tokenId) {
+        if (!requestId.equals(tokenId)) {
+            throw new UnauthorizedException(ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION);
+        }
+    }
+}

--- a/week2_PA/src/main/java/org/geniuus/practice/auth/redis/service/dto/TokenRefreshDto.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/auth/redis/service/dto/TokenRefreshDto.java
@@ -1,0 +1,10 @@
+package org.geniuus.practice.auth.redis.service.dto;
+
+public record TokenRefreshDto(
+        Long memberId,
+        String token
+) {
+    public static TokenRefreshDto of(Long memberId, String token) {
+        return new TokenRefreshDto(memberId, token);
+    }
+}

--- a/week2_PA/src/main/java/org/geniuus/practice/domain/Blog.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/domain/Blog.java
@@ -22,14 +22,26 @@ public class Blog extends BaseTimeEntity {
 
     private String description;
 
-    private Blog(Member member, String title, String description) {
+    private String imageUrl;
+
+    private Blog(Member member, String title, String description, String imageUrl) {
         this.member = member;
         this.title = title;
+        this.imageUrl = imageUrl;
         this.description = description;
     }
 
-    public static Blog create(Member member, BlogCreateRequest blogCreateRequest) {
-        return new Blog(member, blogCreateRequest.title(), blogCreateRequest.description());
+//    public static Blog create(Member member, BlogCreateRequest blogCreateRequest) {
+//        return new Blog(member, blogCreateRequest.title(), blogCreateRequest.description());
+//    }
+
+    public static Blog create(
+            Member member,
+            String title,
+            String description,
+            String imageUrl
+    ) {
+        return new Blog(member, title, imageUrl, description);
     }
 
     public void updateTitle(

--- a/week2_PA/src/main/java/org/geniuus/practice/domain/Member.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/domain/Member.java
@@ -1,13 +1,16 @@
 package org.geniuus.practice.domain;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
@@ -15,23 +18,20 @@ public class Member {
 
     private String name;
 
+    private String password;
+
     @Enumerated(EnumType.STRING)
     private Part part;
 
     private int age;
 
-    @Builder
-    private Member(String name, Part part, int age) {
-        this.name = name;
-        this.part = part;
-        this.age = age;
-    }
 
-    public static Member create(String name, Part part, int age) {
+    public static Member create(String name, String password, Part part, int age) {
         return Member.builder()
                 .name(name)
-                .age(age)
+                .password(password)
                 .part(part)
+                .age(age)
                 .build();
     }
 }

--- a/week2_PA/src/main/java/org/geniuus/practice/external/AwsConfig.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/external/AwsConfig.java
@@ -1,0 +1,48 @@
+package org.geniuus.practice.external;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class AwsConfig {
+
+    private static final String AWS_ACCESS_KEY_ID = "aws.accessKeyId";
+    private static final String AWS_SECRET_ACCESS_KEY = "aws.secretAccessKey";
+
+    private final String accessKey;
+    private final String secretKey;
+    private final String regionString;
+
+    public AwsConfig(@Value("${aws-property.access-key}") final String accessKey,
+                     @Value("${aws-property.secret-key}") final String secretKey,
+                     @Value("${aws-property.aws-region}") final String regionString) {
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
+        this.regionString = regionString;
+    }
+
+
+    @Bean
+    public SystemPropertyCredentialsProvider systemPropertyCredentialsProvider() {
+        System.setProperty(AWS_ACCESS_KEY_ID, accessKey);
+        System.setProperty(AWS_SECRET_ACCESS_KEY, secretKey);
+        return SystemPropertyCredentialsProvider.create();
+    }
+
+    @Bean
+    public Region getRegion() {
+        return Region.of(regionString);
+    }
+
+    @Bean
+    public S3Client getS3Client() {
+        return S3Client.builder()
+                .region(getRegion())
+                .credentialsProvider(systemPropertyCredentialsProvider())
+                .build();
+    }
+}

--- a/week2_PA/src/main/java/org/geniuus/practice/external/S3Service.java
+++ b/week2_PA/src/main/java/org/geniuus/practice/external/S3Service.java
@@ -1,0 +1,80 @@
+package org.geniuus.practice.external;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class S3Service {
+
+    private final String bucketName;
+    private final AwsConfig awsConfig;
+    private static final List<String> IMAGE_EXTENSIONS = Arrays.asList("image/jpeg", "image/png", "image/jpg", "image/webp");
+
+
+    public S3Service(@Value("${aws-property.s3-bucket-name}") final String bucketName, AwsConfig awsConfig) {
+        this.bucketName = bucketName;
+        this.awsConfig = awsConfig;
+    }
+
+
+    public String uploadImage(String directoryPath, MultipartFile image) throws IOException {
+        final String key = directoryPath + generateImageFileName();
+        final S3Client s3Client = awsConfig.getS3Client();
+
+        validateExtension(image);
+        validateFileSize(image);
+
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(image.getContentType())
+                .contentDisposition("inline")
+                .build();
+
+        RequestBody requestBody = RequestBody.fromBytes(image.getBytes());
+        s3Client.putObject(request, requestBody);
+        return key;
+    }
+
+    public void deleteImage(String key) throws IOException {
+        final S3Client s3Client = awsConfig.getS3Client();
+
+        s3Client.deleteObject((DeleteObjectRequest.Builder builder) ->
+                builder.bucket(bucketName)
+                        .key(key)
+                        .build()
+        );
+    }
+
+
+    private String generateImageFileName() {
+        return UUID.randomUUID() + ".jpg";
+    }
+
+
+    private void validateExtension(MultipartFile image) {
+        String contentType = image.getContentType();
+        if (!IMAGE_EXTENSIONS.contains(contentType)) {
+            throw new RuntimeException("이미지 확장자는 jpg, png, webp만 가능합니다.");
+        }
+    }
+
+    private static final Long MAX_FILE_SIZE = 5 * 1024 * 1024L;
+
+    private void validateFileSize(MultipartFile image) {
+        if (image.getSize() > MAX_FILE_SIZE) {
+            throw new RuntimeException("이미지 사이즈는 5MB를 넘을 수 없습니다.");
+        }
+    }
+
+}

--- a/week2_PA/src/test/java/org/geniuus/practice/Controller/MemberControllerTest.java
+++ b/week2_PA/src/test/java/org/geniuus/practice/Controller/MemberControllerTest.java
@@ -4,7 +4,7 @@ import io.restassured.RestAssured;
 import org.assertj.core.api.Assertions;
 import org.geniuus.practice.Repository.MemberRepository;
 import org.geniuus.practice.Service.MemberService;
-import org.geniuus.practice.Service.dto.MemberCreateDto;
+import org.geniuus.practice.Service.dto.MemberCreateRequest;
 import org.geniuus.practice.Settings.ApiTest;
 import org.geniuus.practice.domain.Part;
 import org.junit.jupiter.api.DisplayName;
@@ -30,7 +30,7 @@ public class MemberControllerTest extends ApiTest {
         @DisplayName("요청 성공 테스트")
         public void createMemberSuccess() throws Exception {
             // given
-            final var request = new MemberCreateDto(
+            final var request = new MemberCreateRequest(
                     "geniuus",
                     Part.SERVER,
                     26


### PR DESCRIPTION
# Overview
 - 로그인을 진행할 때 AccessToken과 Refresh Token을 함께 반환하는 로직 
 - Redis를 활용해 Refresh Token으로 Access Token을 재발급 받는 로직
 - API 명세서 작성
 - closes #9  

</br>

# API 명세서

## 개요
- 로그인 API
- 토큰 재발급 API

</br>

## 엔드포인트 목록

| Path                   | Method | Description                |
|------------------------|--------|---------------------|
| `/api/v1/member/login`      | POST    | 로그인      |
| `/api/v1/reissuance`      | POST   | 토큰 재발급    |


</br>

## 각 엔드포인트 상세

### POST `/api/v1/member/login`

#### Request
1. Path Parameter : X
2. Request Header : X
3. Request Body

  | Name                   | Type | Description                |
  |------------------------|--------|---------------------|
  | memberId      | Long   | 로그인할 멤버의 id    |
  | password | String    | 로그인할 멤버의 비밀번호     |

```json
{
    "memberId" : 152,
    "password" : "geniuus"
}
```

#### Response
1. Response Body

  | Status                   | Status Code | Description |
  |------------------------|--------|----------------|
  | 성공      | 200 OK   |  
  | 실패      | 404 Not Found   | id에 해당하는 멤버가 존재하지 않는 경우 | 

  | Name                   | Type | Description                |
  |------------------------|--------|---------------------|
  | accessToken      | Long   | 로그인한 멤버의 Access Token    |
  | refreshToken | String    | 로그인한 멤버의 Refresh Token     |
  | memberId | Long    | 로그인한 멤버의 id     |

```json
{
    "status": 200,
    "message": "로그인이 완료되었습니다.",
    "data": {
        "accessToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9.eyJpYXQiOjE3MTY5ODEyMzcsImV4cCI6MTcxODE5MDgzNywibWVtYmVySWQiOjE1Mn0.s_-HQVoAHCYADvZLV-nGnpjOLUyunBBHsYFud6EGB0mzMZDNqEMlbiAjIp4A-Pz0",
        "refrshToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9.eyJpYXQiOjE3MTY5ODEyMzcsImV4cCI6MTcxODE5MDgzNywibWVtYmVySWQiOjE1Mn0.s_-HQVoAHCYADvZLV-nGnpjOLUyunBBHsYFud6EGB0mzMZDNqEMlbiAjIp4A-Pz0",
        "memberId": 152
    }
}
```

</br>

### POST `/api/v1/reissuance`

#### Request
1. Path Parameter : X
2. Request Header : X
3. Request Body : 

  | Key                   | Value | Description                |
  |------------------------|--------|---------------------|
  | memberId      | Long   | 토큰을 재발급할 멤버의 id    |
  | token      | String   | 멤버의 Refresh Token    |

#### Response
1. Response Body

  | Status                   | Status Code | Description |
  |------------------------|--------|----------------|
  | 성공      | 200 OK   |  
  | 실패      | 401 Unauthorized | Refresh Token이 멤버의 Refresh Token과 동일하지 않은 경우 |

  | Key                   | Value | Description                |
  |------------------------|--------|---------------------|
  | memberId      | Long   | 토큰을 재발급한 멤버의 id    |
  | token      | String   | 재발급된 Access Token    |

```json
{
    "status": 200,
    "message": "토큰 재발급이 완료되었습니다.",
    "data": {
        "memberId": 152
        "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9.eyJpYXQiOjE3MTY5ODEyMzcsImV4cCI6MTcxODE5MDgzNywibWVtYmVySWQiOjE1Mn0.s_-HQVoAHCYADvZLV-nGnpjOLUyunBBHsYFud6EGB0mzMZDNqEMlbiAjIp4A-Pz0"
    }
}
```
 
</br>

# 폴더 구조
```
.
├── java
│   └── org
│       └── geniuus
│           └── practice
│               ├── Common
│               │   ├── BusinessException.java
│               │   ├── ForbiddenException.java
│               │   ├── GlobalExceptionHandler.java
│               │   ├── NotFoundException.java
│               │   ├── UnauthorizedException.java
│               │   ├── dto
│               │   │   ├── ErrorMessage.java
│               │   │   ├── ErrorResponse.java
│               │   │   ├── SuccessMessage.java
│               │   │   └── SuccessStatusResponse.java
│               │   └── jwt
│               │       ├── JwtTokenProvider.java
│               │       └── JwtValidationType.java
│               ├── Config
│               │   └── JpaAuditingConfig.java
│               ├── Controller
│               │   ├── BlogController.java
│               │   ├── MemberController.java
│               │   └── PostController.java
│               ├── PracticeApplication.java
│               ├── Repository
│               │   ├── BlogRepository.java
│               │   ├── MemberRepository.java
│               │   └── PostRepository.java
│               ├── Service
│               │   ├── BlogService.java
│               │   ├── MemberService.java
│               │   ├── PostService.java
│               │   └── dto
│               │       ├── ApiResponse.java
│               │       ├── BlogCreateRequest.java
│               │       ├── BlogTitleUpdateRequest.java
│               │       ├── MemberCreateRequest.java
│               │       ├── MemberFindDto.java
│               │       ├── MemberLoginRequest.java
│               │       ├── MemberResponseWithTokens.java
│               │       ├── MembersDto.java
│               │       ├── PostCreateRequest.java
│               │       ├── PostFindResponse.java
│               │       └── PostsFindResponse.java
│               ├── auth
│               │   ├── PrincipalHandler.java
│               │   ├── SecurityConfig.java
│               │   ├── UserAuthentication.java
│               │   ├── filter
│               │   │   ├── CustomAccessDeniedHandler.java
│               │   │   ├── CustomJwtAuthenticationEntryPoint.java
│               │   │   └── JwtAuthenticationFilter.java
│               │   └── redis
│               │       ├── controller
│               │       │   └── TokenController.java
│               │       ├── domain
│               │       │   └── Token.java
│               │       ├── repository
│               │       │   └── RedisTokenRepository.java
│               │       └── service
│               │           ├── TokenService.java
│               │           └── dto
│               │               └── TokenRefreshDto.java
│               ├── domain
│               │   ├── BaseTimeEntity.java
│               │   ├── Blog.java
│               │   ├── Member.java
│               │   ├── Part.java
│               │   └── Post.java
│               └── external
│                   ├── AwsConfig.java
│                   └── S3Service.java
└── resources
    ├── application.yml
    ├── static
    └── templates
```

</br>

# Member Create 변경사항
```java
// Controller
@Autowired
private final PasswordEncoder passwordEncoder;

@Transactional
public MemberResponseWithTokens createMember (MemberCreateRequest memberCreateRequest) {
    Member member = memberRepository.save(
            Member.create(
                    memberCreateRequest.name(),
                    passwordEncoder.encode(memberCreateRequest.password()),
                    memberCreateRequest.part(),
                    memberCreateRequest.age())
    );

    String accessToken = jwtTokenProvider.issueAccessToken(
            UserAuthentication.createUserAuthentication(member.getId()));
    String refreshToken = jwtTokenProvider.issueRefreshToken(
            UserAuthentication.createUserAuthentication(member.getId()));

    tokenService.saveRefreshToken(member.getId(), refreshToken);
    return MemberResponseWithTokens.of(accessToken, refreshToken, member.getId());
}

// TokenService - rtk redis에 저장
public void saveRefreshToken(Long memberId, String refreshToken) {
        redisTokenRepository.save(
                Token.of(memberId, refreshToken));
    }
```
- 로그인 로직에서 비밀번호 입력받는 칸이 없어서 회원가입 시, 비밀번호를 입력하도록 수정하였습니다.
- 비밀번호는 memberCreateRequest에 담겨 있고, 이를 passwordEncoder로 인코딩해 DB에는 암호화된 비밀번호를 저장하도록 했습니다.
- 회원 가입 시에도 로그인과 마찬가지로 atk, rtk를 생성하여 redis에 rtk를 저장합니다.
- 이 두 토큰을 MemberResponseWithTokens dto에 담아 반환합니다.

</br>

# SecurityConfig White List 수정
```java
// SecurityConfig
...
private static final String[] AUTH_WHITE_LIST = {"/api/v1/member", "/api/v1/reissuance"};
...
```
- rtk로 atk를 재발급하는 로직에서는, Filter를 거치지 않도록 (Header에 토큰을 넣지 않아도 통과된다는 뜻) White List에 추가했습니다.

</br>

# Refresh Token 발급 코드
```java
// JwtTokenProvider
...
private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 60 * 60 * 24 * 1000L * 14;

public String issueRefreshToken(final Authentication authentication) {
        return generateToken(authentication, REFRESH_TOKEN_EXPIRATION_TIME);
    }
...
```
- rtk는 만료 시간을 2주로 설정했습니다.

</br>

# 로그인 API
## Controller
```java
@PostMapping("/member/login")
    public ResponseEntity<SuccessStatusResponse<MemberResponseWithTokens>> login(
            @RequestBody MemberLoginRequest memberLoginRequest
    ) {
        return ResponseEntity.status(HttpStatus.OK)
                .body(SuccessStatusResponse.of(SuccessMessage.MEMBER_LOGIN_SUCCESS, memberService.login(memberLoginRequest)));
    }
```
- `@RequestBody` 를 통해 MemberLoginRequest dto를 전달받아 memberService에서 로그인을 진행합니다.
- 로그인이 완료되면, atk와 rtk가 담긴 MemberResponseWithTokens dto와 200 OK를 반환하도록 했습니다.

## DTO
```java
// MemberLoginRequest
public record MemberLoginRequest(
        Long memberId,
        String password
) {
}

// MemberResponseWithTokens
public record MemberResponseWithTokens(
        String accessToken,
        String refreshToken,
        Long memberId
) {

    public static MemberResponseWithTokens of(
            String accessToken,
            String refreshToken,
            Long memberId
    ) {
        return new MemberResponseWithTokens(accessToken, refreshToken, memberId);
    }
}
```

## Service
```java
public MemberResponseWithTokens login(MemberLoginRequest memberLoginRequest) {
        Member member = memberRepository.findById(memberLoginRequest.memberId()).orElseThrow(
                () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND_BY_ID_EXCEPTION)
        );
        registerMember(memberLoginRequest.password(), member);

        String accessToken = jwtTokenProvider.issueAccessToken(
                UserAuthentication.createUserAuthentication(memberLoginRequest.memberId()));
        String refreshToken = jwtTokenProvider.issueRefreshToken(
                UserAuthentication.createUserAuthentication(memberLoginRequest.memberId()));
        tokenService.saveRefreshToken(member.getId(), refreshToken);
        return MemberResponseWithTokens.of(accessToken, refreshToken, memberLoginRequest.memberId());
    }

public void registerMember (String requestPassword, Member member) {
        if (!passwordEncoder.matches(requestPassword, member.getPassword()))
            throw new UnauthorizedException(ErrorMessage.PASSWORD_NOT_MATCHED_EXCEPTION);
    }
```
- memberLoginRequest에 작성된 id 정보로 멤버를 찾습니다. 해당 멤버가 없다면, NotFoundException을 발생시킵니다.
- 멤버가 존재한다면, registerMember 함수에 요청으로 들어온 비밀번호(memberLoginRequest.password) 와 DB의 멤버 정보를 넘겨 PasswordEncoder의 matches로 비밀번호가 맞는지 비교합니다. 비밀번호가 틀리다면, UnauthorizedException을 발생시킵니다.
- 모든 검증 과정이 완료되면 atk와 rtk를 생성하고 redis에 rtk를 저장한 뒤, MemberResponseWithTokens dto를 만들어 반환합니다.

</br>

# 토큰 재발급 API
## Controller
```java
@PostMapping("/reissuance")
    public ResponseEntity<SuccessStatusResponse<TokenRefreshDto>> reissueTokenByRefreshToken(
            @RequestBody TokenRefreshDto tokenRefreshRequest
            ) {
        return ResponseEntity.ok().body(
                SuccessStatusResponse.of(
                        SuccessMessage.TOKEN_REFRESH_SUCCESS,
                        tokenService.reissueAccessTokenByRefreshToken(tokenRefreshRequest)));
    }
```
- `@RequestBody` 를 통해 tokenRefreshRequest를 전달받아 tokenService에서 토큰 재발급을 진행합니다.
- 성공 시 200 OK를 반환하도록 했습니다.

## DTO
```java
public record TokenRefreshDto(
        Long memberId,
        String token
) {
    public static TokenRefreshDto of(Long memberId, String token) {
        return new TokenRefreshDto(memberId, token);
    }
}
```
- 네이밍이 Dto로 둔 이유는 Request, Response에 동일하게 쓰기 위해서입니다.
- 요청으로 들어올 때는 token 필드에 rtk가 들어오고, 응답으로는 atk가 담겨 반환됩니다.

## Service
```java
public TokenRefreshDto reissueAccessTokenByRefreshToken(TokenRefreshDto tokenRefreshRequest) {
        Long tokenId = redisTokenRepository.findByRefreshToken(tokenRefreshRequest.token()).orElseThrow(
                () -> new UnauthorizedException(ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION)
        ).getId();
        Long requestId = tokenRefreshRequest.memberId();
        validateRequestIdWithTokenId(requestId, tokenId);
        String accessToken = jwtTokenProvider.issueAccessToken(UserAuthentication.createUserAuthentication(requestId));
        return TokenRefreshDto.of(requestId, accessToken);
    }

public void validateRequestIdWithTokenId(Long requestId, Long tokenId) {
        if (!requestId.equals(tokenId)) {
            throw new UnauthorizedException(ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION);
        }
    }
```
- 넘겨받은 rtk를 Redis에서 찾습니다. 존재한다면 `getId()` 로 id를 추출하고, 존재하지 않는다면 UnauthorizedException을 발생시킵니다.
- dto로 들어온 멤버의 id와 redis의 rtk와 엮여있는 id 값이 동일한지 검증합니다. `validateRequestIdWithTokenId``
- 검증 과정이 완료되면, atk를 재발급하여 TokenRefreshDto에 담아 반환합니다.

## Repository
```java
public interface RedisTokenRepository extends CrudRepository<Token, Long> {
    Optional<Token> findByRefreshToken(final String refreshToken);
}
```
- CrudRepository를 상속받아 RDB처럼 사용할 수 있게 세팅했습니다.
- RedisTemplate을 사용할 수도 있지만, 복잡한 쿼리나 데이터 구조가 없어 간단하기 때문에 CrudRepository를 사용했습니다.
</br>

# 구현 고민 사항
- TokenRefreshDto에서 dto와 token 필드가 모두 범용성으로 사용될 수 있도록 재사용했는데, 이게 좋은 방법인 지는 잘 모르겠습니다.
- memberService에서 atk, rtk를 생성하는 코드가 반복적으로 이뤄지는데, 이를 묶어서 메소드화하는 것이 좋은 방법일까요?
   저의 개인적인 의견으로는, 생성하는 코드가 의존성을 주입받아 TokenService의 함수를 호출하는 것이기 때문에 이를 묶는다면 TokenService에서 메소드를 묶고 이를 호출하는 것이 좋은 방식이라고 생각되는데, 리뷰어 분들의 의견도 궁금합니다 :)
- 어떤 피드백도 환영입니다 🙌
